### PR TITLE
Added role avoiders + scroll function on settings tab

### DIFF
--- a/src/Client/Module/Modules/AutoRQ/AutoRQ.hpp
+++ b/src/Client/Module/Modules/AutoRQ/AutoRQ.hpp
@@ -32,6 +32,20 @@ public:
             settings.addSetting("command", (std::string)"");
         if (settings.getSettingByName<bool>("solo") == nullptr)
             settings.addSetting("solo", false);
+        if (settings.getSettingByName<bool>("murderer") == nullptr)
+            settings.addSetting("murderer", false);
+        if (settings.getSettingByName<bool>("sheriff") == nullptr)
+            settings.addSetting("sheriff", false);
+        if (settings.getSettingByName<bool>("innocent") == nullptr)
+            settings.addSetting("innocent", false);
+        if (settings.getSettingByName<bool>("hider") == nullptr)
+            settings.addSetting("hider", false);
+        if (settings.getSettingByName<bool>("seeker") == nullptr)
+            settings.addSetting("seeker", false);
+        if (settings.getSettingByName<bool>("death") == nullptr)
+            settings.addSetting("death", false);
+        if (settings.getSettingByName<bool>("runner") == nullptr)
+            settings.addSetting("runner", false);
         if (settings.getSettingByName<bool>("AutoMapAvoider") == nullptr)
             settings.addSetting("AutoMapAvoider", false);
         if (settings.getSettingByName<std::string>("text") == nullptr) 
@@ -44,6 +58,11 @@ public:
 
         const float textWidth = Constraints::RelativeConstraint(0.12, "height", true);
         const float textHeight = Constraints::RelativeConstraint(0.029, "height", true);
+
+        FlarialGUI::ScrollBar(toggleX, toggleY, 140, Constraints::SpacingConstraint(5.5, textWidth), 2);
+        FlarialGUI::SetScrollView(toggleX, Constraints::PercentageConstraint(0.00, "top"),
+                                  Constraints::RelativeConstraint(1.0, "width"),
+                                  Constraints::RelativeConstraint(1.0f, "height"));
 
         FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
                                         L"Solo mode", textWidth * 6.9f, textHeight,
@@ -58,7 +77,122 @@ public:
         toggleY += Constraints::SpacingConstraint(0.35, textWidth);
 
         FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0, textWidth), toggleY,
-                                        L"Avoid Maps (Hive). Input one or more maps using comma's.", textWidth * 6.9f, textHeight,
+                                        L"Re-Q when you get a specific role (Hive)", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0, textWidth), toggleY,
+                                        L"Murder Mystery", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Murderer", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(3, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "murderer")->value))
+            this->settings.getSettingByName<bool>("murderer")->value = !this->settings.getSettingByName<bool>(
+                    "murderer")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Sheriff", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(4, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "sheriff")->value))
+            this->settings.getSettingByName<bool>("sheriff")->value = !this->settings.getSettingByName<bool>(
+                    "sheriff")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Innocent", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(6, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "innocent")->value))
+            this->settings.getSettingByName<bool>("innocent")->value = !this->settings.getSettingByName<bool>(
+                    "innocent")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0, textWidth), toggleY,
+                                        L"Hide and Seek", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+        
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Hider", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(7, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "hider")->value))
+            this->settings.getSettingByName<bool>("hider")->value = !this->settings.getSettingByName<bool>(
+                    "hider")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Seeker", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(8, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "seeker")->value))
+            this->settings.getSettingByName<bool>("seeker")->value = !this->settings.getSettingByName<bool>(
+                    "seeker")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0, textWidth), toggleY,
+                                        L"Deathrun", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Death", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(9, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "death")->value))
+            this->settings.getSettingByName<bool>("death")->value = !this->settings.getSettingByName<bool>(
+                    "death")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth), toggleY,
+                                        L"Runner", textWidth * 6.9f, textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
+
+        if (FlarialGUI::Toggle(10, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "runner")->value))
+            this->settings.getSettingByName<bool>("runner")->value = !this->settings.getSettingByName<bool>(
+                    "runner")->value;
+
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+
+        toggleX = Constraints::PercentageConstraint(0.55, "left");
+        toggleY = Constraints::PercentageConstraint(0.10, "top");
+
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0, textWidth), toggleY,
+                                        L"Avoid Maps (Hive). Input one or more maps\nusing comma's.", textWidth * 6.9f, textHeight,
                                         DWRITE_TEXT_ALIGNMENT_LEADING, Constraints::SpacingConstraint(1.05, textWidth),
                                         DWRITE_FONT_WEIGHT_NORMAL);
 
@@ -72,6 +206,7 @@ public:
          Constraints::SpacingConstraint(0.60, textWidth), toggleY, "");
 
         toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+        FlarialGUI::UnsetScrollView();
     }
 };
 

--- a/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
+++ b/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
@@ -87,6 +87,153 @@ class AutoRQListener : public Listener {
             }
         }
         if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("murderer")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§c§l» §r§c§lMurderer") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Murderer");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("sheriff")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§9§l» §r§9§lSheriff") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Sheriff");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("innocent")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§a§l» §r§a§lInnocent") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Innocent");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("death")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§d§l» §r§bYou are a §cDeath") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Death");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("runner")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§d§l» §r§bYou are a §aRunner") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Runner");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("hider")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§e§l» §rYou are a §eHIDER") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Hider");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
+            if(module->settings.getSettingByName<bool>("seeker")->value){
+                auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
+
+                if (pkt->message == "§c§l» §rYou are a §cSEEKER") {
+                    triggered = true;
+                    FlarialGUI::Notify("Found role Seeker");
+                    std::shared_ptr<Packet> packet = SDK::createPacket(77);
+                    auto* command_packet = reinterpret_cast<CommandRequestPacket*>(packet.get());
+
+                    command_packet->command = "/connection";
+
+                    command_packet->origin.type = CommandOriginType::Player;
+
+                    command_packet->InternalSource = true;
+
+                    SDK::clientInstance->getPacketSender()->sendToServer(command_packet);
+
+                } //std::cout << pkt->mName << std::endl;
+            }
+        }
+        if (id == MinecraftPacketIds::Text) {
             if(module->settings.getSettingByName<bool>("AutoMapAvoider")->value){
                 auto *pkt = reinterpret_cast<TextPacket *>(event.getPacket());
                 std::string maps_to_avoid = module->settings.getSettingByName<std::string>("text")->value;


### PR DESCRIPTION
Added a role avoider. I got the idea from a [suggestion](https://discord.com/channels/1158057414583652372/1263448654665093231/1263448654665093231) on OderSo client discord. All roles from the 3 gamemodes mentioned are added:
```
im writing to you today to request the addition of auto rq on roles in oderso client. this feature would greatly benefit players and make it much easier for them to navigate thru the game

autorq on roles would save players time and effort by automatically requeuing ‘em for specific roles that they prefer
this is also would eliminate the need for players to constantly monitor and reselect their preferred roles or allowing them to focus more 

example:

In Murder Mystery: Rq when your role: Murderer
In Death Run: Rq when when your role: Death (role)
In Hide And Seek: Rq when your role: Seeker (for players, who wants to be Hider everytime)```