### PR TITLE
Several multi-version fixes

### DIFF
--- a/src/Client/Client.cpp
+++ b/src/Client/Client.cpp
@@ -102,7 +102,7 @@ void Client::initialize() {
         Client::settings.addSetting("blurintensity", 18.0f);
 
     if (Client::settings.getSettingByName<bool>("killdx") == nullptr)
-        Client::settings.addSetting("killdx", false);
+        Client::settings.addSetting("killdx", true); // TODO: Fix dx12 stuff and set this to false again
 
     if (Client::settings.getSettingByName<bool>("disable_alias") == nullptr)
         Client::settings.addSetting("disable_alias", false);

--- a/src/Client/Hook/Hooks/Render/SetupAndRenderHook.hpp
+++ b/src/Client/Hook/Hooks/Render/SetupAndRenderHook.hpp
@@ -51,6 +51,31 @@ private:
 		);
 	}
 
+	static void drawImageDetour2120(
+		MinecraftUIRenderContext* _this,
+		TexturePtr* texturePtr,
+		Vec2<float>& imagePos,
+		Vec2<float>& imageDimension,
+		Vec2<float>& uvPos,
+		Vec2<float>& uvSize,
+		bool unk
+	)
+	{
+		DrawImageEvent event(texturePtr, imagePos);
+		EventHandler::onDrawImage(event);
+
+		Memory::CallFunc<void*, MinecraftUIRenderContext*, TexturePtr*, Vec2<float>&, Vec2<float>&, Vec2<float>&, Vec2<float>&>(
+				oDrawImage,
+				_this,
+				texturePtr,
+				event.getImagePos(),
+				imageDimension,
+				uvPos,
+				uvSize,
+				unk
+		);
+	}
+
     static void hookDrawTextAndDrawImage(MinecraftUIRenderContext* muirc) {
         auto vTable = *(uintptr_t **) muirc;
 
@@ -59,11 +84,12 @@ private:
                              "drawText");
         }
 
-        if(!WinrtUtils::check(21,20)) { // TODO
-            if (oDrawImage == nullptr) {
-                Memory::hookFunc((void *) vTable[7], (void *) drawImageDetour, (void **) &oDrawImage, "DrawImage");
-            }
-        }
+		if (oDrawImage == nullptr) {
+			if (WinrtUtils::check(21, 20))
+				Memory::hookFunc((void *) vTable[7], (void *) drawImageDetour2120, (void **) &oDrawImage, "DrawImage");
+			else
+				Memory::hookFunc((void *) vTable[7], (void *) drawImageDetour, (void **) &oDrawImage, "DrawImage");
+		}
     }
 
 	static void setUpAndRenderCallback(ScreenView* pScreenView, MinecraftUIRenderContext* muirc) {

--- a/src/Client/Hook/Manager.cpp
+++ b/src/Client/Hook/Manager.cpp
@@ -59,9 +59,7 @@ void HookManager::initialize() {
     hooks.push_back(new OnSuspendHook());
     hooks.push_back(new getGammaHook());
     hooks.push_back(new FontDrawTransformedHook());
-    if(!WinrtUtils::check(21,20)) { // TODO
-        hooks.push_back(new HurtColorHook());
-    }
+    hooks.push_back(new HurtColorHook());
     hooks.push_back(new DimensionFogColorHook());
     hooks.push_back(new OverworldFogColorHook());
     hooks.push_back(new TimeChangerHook());

--- a/src/Client/Module/Manager.cpp
+++ b/src/Client/Module/Manager.cpp
@@ -125,9 +125,7 @@ void ModuleManager::initialize() {
     addModule(new Hitbox());
     addModule(new ThirdPerson());
     addModule(new SnapLook());
-    if(!WinrtUtils::check(21,20)) { // TODO
-        addModule(new HurtColor());
-    }
+    addModule(new HurtColor());
     addModule(new FogColor());
     addModule(new ArmorHUD());
 

--- a/src/Client/Module/Manager.cpp
+++ b/src/Client/Module/Manager.cpp
@@ -131,9 +131,7 @@ void ModuleManager::initialize() {
 
     addModule(new TimeChanger());
 
-    if((WinrtUtils::check(20,30) && !WinrtUtils::check(20,40)) || WinrtUtils::check(20,50)) { // does not work in 1.20.4X
-        addModule(new RenderOptions());
-    }
+    addModule(new RenderOptions());
 
     addModule(new PaperDoll());
     addModule(new GuiScale());

--- a/src/Client/Module/Modules/WeatherChanger/WeatherChanger.hpp
+++ b/src/Client/Module/Modules/WeatherChanger/WeatherChanger.hpp
@@ -66,21 +66,17 @@ public:
 
         this->settings.getSettingByName<float>("lighting")->value = percent;
 
-        if (!WinrtUtils::check(21, 0)) {
-
-            toggleY += Constraints::SpacingConstraint(0.35, textWidth);
-            if (FlarialGUI::Toggle(0, toggleX, toggleY, this->settings.getSettingByName<bool>(
-                    "snow")->value))
-                this->settings.getSettingByName<bool>("snow")->value = !this->settings.getSettingByName<bool>(
-                        "snow")->value;
-            FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth / 2.0f), toggleY,
-                                            L"Snow (intensity depends on rain)",
-                                            Constraints::SpacingConstraint(4.5, textWidth), textHeight,
-                                            DWRITE_TEXT_ALIGNMENT_LEADING,
-                                            Constraints::SpacingConstraint(0.95, textWidth),
-                                            DWRITE_FONT_WEIGHT_NORMAL);
-
-        }
+        toggleY += Constraints::SpacingConstraint(0.35, textWidth);
+        if (FlarialGUI::Toggle(0, toggleX, toggleY, this->settings.getSettingByName<bool>(
+                "snow")->value))
+            this->settings.getSettingByName<bool>("snow")->value = !this->settings.getSettingByName<bool>(
+                    "snow")->value;
+        FlarialGUI::FlarialTextWithFont(toggleX + Constraints::SpacingConstraint(0.60, textWidth / 2.0f), toggleY,
+                                        L"Snow (intensity depends on rain)",
+                                        Constraints::SpacingConstraint(4.5, textWidth), textHeight,
+                                        DWRITE_TEXT_ALIGNMENT_LEADING,
+                                        Constraints::SpacingConstraint(0.95, textWidth),
+                                        DWRITE_FONT_WEIGHT_NORMAL);
     }
 };
 

--- a/src/Client/Module/Modules/WeatherChanger/WeatherListener.hpp
+++ b/src/Client/Module/Modules/WeatherChanger/WeatherListener.hpp
@@ -26,14 +26,12 @@ class WeatherListener : public Listener {
                         "lighting")->value;
             else SDK::clientInstance->getBlockSource()->getDimension()->weather->lightingLevel = 0.0f;
 
-            if (!WinrtUtils::check(21, 0)) {
-                // TODO: When you set snow, it will stay even if on until game reload
-                if (module->settings.getSettingByName<bool>("snow")->value) {
-                    Vec3<float> *pos = event.getActor()->getPosition();
-                    Vec3<int> e((int)pos->x, (int)pos->y, (int)pos->z);
+            // TODO: When you set snow, it will stay even if on until game reload
+            if (module->settings.getSettingByName<bool>("snow")->value) {
+                Vec3<float> *pos = event.getActor()->getPosition();
+                Vec3<int> e((int)pos->x, (int)pos->y, (int)pos->z);
 
-                    SDK::clientInstance->getBlockSource()->getBiome(e)->temparature = 0.0f;
-                }
+                SDK::clientInstance->getBlockSource()->getBiome(e)->temparature = 0.0f;
             }
         }
     }

--- a/src/SDK/Client/Actor/Actor.cpp
+++ b/src/SDK/Client/Actor/Actor.cpp
@@ -66,13 +66,8 @@ uint64_t Actor::getRuntimeID() {
 
 ActorDataFlagComponent* Actor::getActorDataFlagComponent() {
     if(!WinrtUtils::check(20, 80)) return nullptr;
-    static uintptr_t sig;
 
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getActorDataFlagComponent"));
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix2"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix2")) + " " + GET_SIG("Actor::getActorDataFlagComponent"));
 
     return tryGet<ActorDataFlagComponent>(sig);
 }
@@ -95,26 +90,16 @@ Vec3<float> *Actor::getPosition() {
 
 SimpleContainer* Actor::getArmorContainer() {
     if(!WinrtUtils::check(20, 80)) return nullptr;
-    static uintptr_t sig;
 
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getActorEquipmentComponent"));
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix2"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix2")) + " " + GET_SIG("Actor::getActorEquipmentComponent"));
 
     return tryGet<ActorEquipmentComponent>(sig)->mArmorContainer;
 }
 
 SimpleContainer* Actor::getOffhandContainer() {
     if(!WinrtUtils::check(20, 80)) return nullptr;
-    static uintptr_t sig;
 
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getActorEquipmentComponent"));
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix2"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix2")) + " " + GET_SIG("Actor::getActorEquipmentComponent"));
 
     return tryGet<ActorEquipmentComponent>(sig)->mOffhandContainer;
 }
@@ -136,52 +121,28 @@ ItemStack *Actor::getArmor(int slot) {
 
 MoveInputComponent *Actor::getMoveInputHandler() { //??$try_get@UMoveInputComponent
 
-    static uintptr_t sig;
-
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getMoveInputHandler")); // 8B DA BA 2E CD 8B 46
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getMoveInputHandler"));
 
     return tryGet<MoveInputComponent>(sig);
 }
 
 ActorGameTypeComponent *Actor::getGameModeType() {
 
-    static uintptr_t sig;
-
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getActorGameTypeComponent")); // 8B DA BA DE AB CB AF
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getActorGameTypeComponent"));
 
     return tryGet<ActorGameTypeComponent>(sig);
 }
 
 AABBShapeComponent *Actor::getAABBShapeComponent() {
 
-    static uintptr_t sig;
-
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getAABBShapeComponent")); // 8B DA BA F2 C9 10 1B
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getAABBShapeComponent"));
 
     return tryGet<AABBShapeComponent>(sig);
 }
 
 StateVectorComponent *Actor::getStateVectorComponent() {
 
-    static uintptr_t sig;
-
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getStateVectorComponent")); // 8B DA BA 91 3C C9 0E
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getStateVectorComponent"));
 
     return tryGet<StateVectorComponent>(sig);
 }
@@ -202,13 +163,7 @@ ItemStack *Actor::getOffhandSlot() {
 }
 
 RuntimeIDComponent *Actor::getRuntimeIDComponent() {
-    static uintptr_t sig;
-
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getRuntimeIDComponent")); // 8B DA BA 14 14 A1 3C
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getRuntimeIDComponent"));
 
     return tryGet<RuntimeIDComponent>(sig);
 }
@@ -244,13 +199,7 @@ bool Actor::hasCategory(ActorCategory category) {
 }
 
 RenderPositionComponent *Actor::getRenderPositionComponent() { //??$try_get@URenderPositionComponent
-    static uintptr_t sig;
-
-    if (sig == NULL) {
-        sig = Memory::findSig(GET_SIG("Actor::getRenderPositionComponent")); // 8B DA BA 6E F3 E8 D4
-        auto size = Utils::CountBytes(GET_SIG("tryGetPrefix"));
-        sig = sig - size;
-    }
+    static uintptr_t sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getRenderPositionComponent"));
 
     return tryGet<RenderPositionComponent>(sig);
 }

--- a/src/SDK/Client/Core/Options.hpp
+++ b/src/SDK/Client/Core/Options.hpp
@@ -35,9 +35,7 @@ public:
     static void initialize(const uintptr_t optionsEntryPtr){
         optionsBaseEntry = (uintptr_t **) optionsEntryPtr;
         initialized = true;
-        if((WinrtUtils::check(20,30) && !WinrtUtils::check(20,40)) || WinrtUtils::check(20,50)) { // does not work in 1.20.4X (crashes)
-            initVsync();
-        }
+        initVsync();
     };
 
     static bool isInitialized() {
@@ -77,8 +75,7 @@ public:
         return nullptr;
     };
     static Option* getOption(const std::string& optionName) {
-        // disable getting settings in 1.20.4X
-        if(!isInitialized() || !((WinrtUtils::check(20,30) && !WinrtUtils::check(20,40)) || WinrtUtils::check(20,50))) return nullptr;
+        if(!isInitialized()) return nullptr;
         std::hash<std::string> optionNameHash;
 
         UINT32 key = optionNameHash(optionName);

--- a/src/Utils/Memory/Game/Offset/OffsetInit.cpp
+++ b/src/Utils/Memory/Game/Offset/OffsetInit.cpp
@@ -169,6 +169,8 @@ void OffsetInit::init2040() {
 
     ADD_OFFSET("Level::hitResult", 0xA68);
     ADD_OFFSET("Level::getPlayerMap", 0x25F0);
+
+    ADD_OFFSET("OptionInfo::TranslateName", 0x168);
 }
 
 void OffsetInit::init2030() {

--- a/src/Utils/Memory/Game/Sig/SigInit.cpp
+++ b/src/Utils/Memory/Game/Sig/SigInit.cpp
@@ -123,7 +123,7 @@ void SigInit::init2050() {
 
     ADD_SIG("Level::getRuntimeActorList", "40 53 48 83 EC 30 48 81 C1 D8 1C 00 00");
 
-    ADD_SIG("ItemPositionConst", "F3 0F 59 ? ? ? ? ? F3 41 0F 58 ? ? ? ? ? ? F3 0F 59 ? ? ? ? ? F3 0F 2C");
+    ADD_SIG("ItemPositionConst", "F3 0F 59 ? ? ? ? ? F3 41 0F 58 ? ? ? ? ? ? F3 0F 59 ? ? ? ? ? F3 0F 2C"); // Yes this is the same sig as 1.20.30
 
     ADD_SIG("ItemRenderer::render", "48 8B C4 48 89 58 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 0F 29 70 ? 0F 29 78 ? 44 0F 29 40 ? 44 0F 29 48 ? 44 0F 29 90 ? ? ? ? 44 0F 29 98 ? ? ? ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 45 ? 49 8B D8");
 }

--- a/src/Utils/Memory/Game/Sig/SigInit.cpp
+++ b/src/Utils/Memory/Game/Sig/SigInit.cpp
@@ -123,6 +123,8 @@ void SigInit::init2050() {
 
     ADD_SIG("Level::getRuntimeActorList", "40 53 48 83 EC 30 48 81 C1 D8 1C 00 00");
 
+    ADD_SIG("ItemPositionConst", "F3 0F 59 ? ? ? ? ? F3 41 0F 58 ? ? ? ? ? ? F3 0F 59 ? ? ? ? ? F3 0F 2C");
+
     ADD_SIG("ItemRenderer::render", "48 8B C4 48 89 58 ? 55 56 57 41 54 41 55 41 56 41 57 48 8D A8 ? ? ? ? 48 81 EC ? ? ? ? 0F 29 70 ? 0F 29 78 ? 44 0F 29 40 ? 44 0F 29 48 ? 44 0F 29 90 ? ? ? ? 44 0F 29 98 ? ? ? ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 45 ? 49 8B D8");
 }
 
@@ -136,6 +138,8 @@ void SigInit::init2040() {
     ADD_SIG("Actor::canSee", "E8 ? ? ? ? 84 C0 74 1C 48 8B 4F 48");
 
     ADD_SIG("Level::getRuntimeActorList", "40 53 48 83 EC 30 48 81 C1 78");
+
+    ADD_SIG("ItemPositionConst", "F3 0F 59 05 ? ? ? ? F3 41 0F 58 87");
 }
 
 void SigInit::init2030() {

--- a/src/Utils/Memory/Game/Sig/SigInit.cpp
+++ b/src/Utils/Memory/Game/Sig/SigInit.cpp
@@ -18,6 +18,8 @@ void SigInit::init2120() {
     ADD_SIG("Level::getRuntimeActorList", "40 53 48 83 EC 30 48 81 C1 40");
 
     ADD_SIG("ActorCollision::isOnGround", "E8 ? ? ? ? 84 C0 49 8B 87");
+
+    ADD_SIG("HurtColor", "E8 ? ? ? ? E9 ? ? ? ? 8B 43 ? 48 8D 54 24 ? 48 8B 4B ? 89 44 24 ? E8 ? ? ? ? 4C 8B D8");
 }
 
 void SigInit::init2102() {

--- a/src/Utils/Memory/Game/Sig/SigInit.cpp
+++ b/src/Utils/Memory/Game/Sig/SigInit.cpp
@@ -31,7 +31,7 @@ void SigInit::init2102() {
 void SigInit::init2100() {
     Logger::debug("[Signatures] Loading sigs for 1.21.0X");
 
-    ADD_SIG("BlockSource::getBiome", "48 89 5C 24 18 57 48 83 EC 50 48 8B F9 E8");
+    ADD_SIG("BlockSource::getBiome", "40 53 48 83 EC ? 48 8B D9 E8 ? ? ? ? 48 85 C0 75 ? 48 8B 03");
     ADD_SIG("Level::getRuntimeActorList", "40 53 48 83 EC 30 48 81 C1 10");
 
     ADD_SIG("ActorCollision::isOnGround", "E8 ? ? ? ? 88 45 FF");


### PR DESCRIPTION
IMPORTANT: THIS PULL REQUEST SETS KILLDX TO TRUE BECAUSE DX12 IS UNSTABLE! PLEASE SET THE DEFAULT VALUE TO FALSE AGAIN AFTER DX12 COMPATIBILITY IS FIXED!!!

- Fix MinecraftUIRenderContext::drawImage hook for 1.21.2X (fixes Animations)
- Fix HurtColor hook for 1.21.2X
- Fix snow option in WeatherChanger for 1.21.0+ (1.21.0, 1.21.1, 1.21.20, 1.21.21)
- Fix ItemPhysics crashing in 1.20.4X
- Fix RenderOptions for 1.20.4X
- Fix old try_get method being unreliable