### PR TITLE
Full name for re-Q notifications

### DIFF
--- a/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
+++ b/src/Client/Module/Modules/AutoRQ/AutoRQListener.hpp
@@ -195,9 +195,7 @@ class AutoRQListener : public Listener {
 
     void reQ() {
         if (!module->settings.getSettingByName<bool>("hub")->value) {
-            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-
-            FlarialGUI::Notify("Executing command /q " + HiveModeCatcherListener::currentGame);
+            FlarialGUI::Notify("Finding a new game of " + HiveModeCatcherListener::fullgamemodename);
 
             std::shared_ptr<Packet> packet = SDK::createPacket(77);
             auto *command_packet = reinterpret_cast<CommandRequestPacket *>(packet.get());

--- a/src/Client/Module/Modules/HiveModeCatcher/HiveModeCatcherListener.hpp
+++ b/src/Client/Module/Modules/HiveModeCatcher/HiveModeCatcherListener.hpp
@@ -51,7 +51,181 @@ class HiveModeCatcherListener : public Listener {
                 HiveModeCatcherListener::currentGame = std::regex_replace(server, pattern, "");
                 event.cancel();
                 listenForServer = true;
+                HiveModeCatcherListener::fullgamemodename = currentGame;
+                //Give Hive's Gamemodes their full names. Should only be used for visual stuff.
+                // HUB
+                if (fullgamemodename == "HUB")
+                {
+                    fullgamemodename = "Hub";
+                }
+                // REPLAYCINEMA (NEEDS TO GET TESTED)
+                if (fullgamemodename == "REPLAY")
+                {
+                    fullgamemodename = "Replay Cinema";
+                }
+                // BEDWARS
+                else if (fullgamemodename == "HUB-BED")
+                {
+                    fullgamemodename = "Bedwars Hub";
+                }
+                else if (fullgamemodename == "BED")
+                {
+                    fullgamemodename = "Bedwars Solo";
+                }
+                else if (fullgamemodename == "BED-DUOS")
+                {
+                    fullgamemodename = "Bedwars Duos";
+                }
+                else if (fullgamemodename == "BED-SQUADS")
+                {
+                    fullgamemodename = "Bedwars Squads";
+                }
+                // SKYWARS
+                else if (fullgamemodename == "HUB-SKY")
+                {
+                    fullgamemodename = "Skywars Hub";
+                }
+                else if (fullgamemodename == "SKY")
+                {
+                    fullgamemodename = "Skywars Solo";
+                }
+                else if (fullgamemodename == "SKY-DUOS")
+                {
+                    fullgamemodename = "Skywars Duos";
+                }
+                else if (fullgamemodename == "SKY-SQUADS")
+                {
+                    fullgamemodename = "Skywars Squads";
+                }
+                else if (fullgamemodename == "SKY-CLASSIC")
+                {
+                    fullgamemodename = "Skywars Classic Solo";
+                }
+                else if (fullgamemodename == "SKY-CLASSIC-SQUADS")
+                {
+                    fullgamemodename = "Skywars Classic Squads";
+                }
+                else if (fullgamemodename == "SKY-KITS")
+                {
+                    fullgamemodename = "Skywars Kits Solo";
+                }
+                else if (fullgamemodename == "SKY-KITS-DUOS")
+                {
+                    fullgamemodename = "Skywars Kits Duos";
+                }
+                // PARKOURWORLD
+                else if (fullgamemodename == "HUB-PARKOUR")
+                {
+                    fullgamemodename = "Parkour world";
+                }
+                // JUSTBUILD
+                else if (fullgamemodename == "BUILD")
+                {
+                    fullgamemodename = "Just Build Solo";
+                }
+                else if (fullgamemodename == "BUILD-DUOS")
+                {
+                    fullgamemodename = "Just Build Duos";
+                }
+                else if (fullgamemodename == "BUILDX")
+                {
+                    fullgamemodename = "Just Build Double Build Time Solo";
+                }
+                else if (fullgamemodename == "BUILD-DUOSX")
+                {
+                    fullgamemodename = "Just Build Double Build Time Duos";
+                }
+                // MURDER MYSTERY
+                else if (fullgamemodename == "MURDER")
+                {
+                    fullgamemodename = "Murder Mystery";
+                }
+                // HIDEANDSEEK
+                else if (fullgamemodename == "HIDE")
+                {
+                    fullgamemodename = "Hide And Seek";
+                }
+                // CAPTURETHEFLAG
+                else if (fullgamemodename == "CTF")
+                {
+                    fullgamemodename = "Capture The Flag";
+                }
+                // DEATHRUN
+                else if (fullgamemodename == "DR")
+                {
+                    fullgamemodename = "Death Run";
+                }
+                // THEBRIDGE
+                else if (fullgamemodename == "BRIDGE")
+                {
+                    fullgamemodename = "The Bridge Solo";
+                }
+                else if (fullgamemodename == "BRIDGE-DUOS")
+                {
+                    fullgamemodename = "The Bridge Duos";
+                }
+                // BLOCKPARTY
+                else if (fullgamemodename == "PARTY")
+                {
+                    fullgamemodename = "Block Party";
+                }
+                // SURVIVALGAME
+                else if (fullgamemodename == "SG")
+                {
+                    fullgamemodename = "Survival Games Solo";
+                }
+                else if (fullgamemodename == "SG-DUOS")
+                {
+                    fullgamemodename = "Survival Games Duos";
+                }
+                else if (fullgamemodename == "SG-DUOS")
+                {
+                    fullgamemodename = "Survival Games Duos";
+                }
+                // GRAVITY
+                else if (fullgamemodename == "GRAV")
+                {
+                    fullgamemodename = "Gravity";
+                }
+                // GROUNDWARS
+                else if (fullgamemodename == "GROUND")
+                {
+                    fullgamemodename = "Ground Wars";
+                }
+                // BLOCKDROP
+                else if (fullgamemodename == "DROP")
+                {
+                    fullgamemodename = "Block Drop";
+                }
 
+                //  Seasonal / custom server only games 
+
+                // TREASUREWARS
+                else if (fullgamemodename == "WARS")
+                {
+                    fullgamemodename = "Treasure Wars Solo";
+                }
+                else if (fullgamemodename == "WARS-DUOS")
+                {
+                    fullgamemodename = "Treasure Wars Duos";
+                }
+                else if (fullgamemodename == "WARS-TRIOS")
+                {
+                    fullgamemodename = "Treasure Wars Trios";
+                }
+                else if (fullgamemodename == "WARS-SQUADS")
+                {
+                    fullgamemodename = "Treasure Wars Squads";
+                }
+                else if (fullgamemodename == "WARS-MEGA")
+                {
+                    fullgamemodename = "Treasure Wars Mega";
+                }
+                // GHOSTINVASION
+                else if (fullgamemodename == "GI")
+                {
+                    fullgamemodename = "Ghost Invasion";
+                }
             } else if (pkt->message.find(textToCheckToSilence) != std::string::npos) {
                 event.cancel();
             }
@@ -64,4 +238,5 @@ public:
         this->name = string;
     }
     static inline std::string currentGame;
+    static inline std::string fullgamemodename;
 };


### PR DESCRIPTION
Added code that formats Hive's gamemode names to be their full name. (example ``BED-DUOS`` will be ``Bedwars Duos``)

This is currently used for the re-q notification
and will be used for Discord RPC in the next pull (if this one is good and gets accepted).