### PR TITLE
Fix dropdown hover cursor and toggle behavior

### DIFF
--- a/src/Client/GUI/Engine/Elements/Control/Dropdown/Dropdown.cpp
+++ b/src/Client/GUI/Engine/Elements/Control/Dropdown/Dropdown.cpp
@@ -71,11 +71,11 @@ std::string FlarialGUI::Dropdown(int index, float x, float y, const std::vector<
 		}
 	}
 
-	if (!activeColorPickerWindows && CursorInRect(x, clickingY, Constraints::SpacingConstraint(1.85, textWidth), percHeight + maxHeight)) {
-		if (MC::mouseButton == MouseButton::Left &&
+	if (!activeColorPickerWindows && CursorInRect(x, clickingY, Constraints::SpacingConstraint(1.85, textWidth), FlarialGUI::DropDownMenus[index].isActive ? percHeight + maxHeight : percHeight)) {
+		if (MC::mouseButton == MouseButton::Left && !MC::held &&
 			CursorInRect(x, clickingY, Constraints::SpacingConstraint(1.85, textWidth), percHeight)) {
-			//MC::mouseButton = MouseButton::None;
-			FlarialGUI::DropDownMenus[index].isActive = true;
+			MC::mouseButton = MouseButton::None;
+			FlarialGUI::DropDownMenus[index].isActive = !FlarialGUI::DropDownMenus[index].isActive;
 			value = FlarialGUI::DropDownMenus[index].selected;
 		}
 		if (DropDownMenus[index].firstHover) {
@@ -83,7 +83,7 @@ std::string FlarialGUI::Dropdown(int index, float x, float y, const std::vector<
 			DropDownMenus[index].firstHover = false;
 		}
 	}
-	else if (!CursorInRect(x, clickingY, Constraints::SpacingConstraint(1.85, textWidth), percHeight + maxHeight)) {
+	else if (!CursorInRect(x, clickingY, Constraints::SpacingConstraint(1.85, textWidth), FlarialGUI::DropDownMenus[index].isActive ? percHeight + maxHeight : percHeight)) {
 		if (MC::mouseButton == MouseButton::Left) {
 			FlarialGUI::DropDownMenus[index].isActive = false;
 			value = FlarialGUI::DropDownMenus[index].selected;


### PR DESCRIPTION
## Summary
- Fixed cursor appearing on entire dropdown length when not toggled by conditionally using dropdown height based on active state
- Made dropdown header clickable to toggle open/closed state with proper toggle logic
- Prevented spam toggling during mouse hold by adding MC::held check to click detection
- Cursor now only shows hover state on actual dropdown area, not the extended area when closed

## Test plan
- [ ] Test dropdown cursor only appears when hovering over visible dropdown area
- [ ] Test clicking dropdown header toggles open/closed state
- [ ] Test holding mouse button down doesn't cause spam toggling
- [ ] Test dropdown options are still clickable when open
- [ ] Test clicking outside dropdown closes it as expected