### PR TITLE
fix: TextHotkey.cpp

### DIFF
--- a/src/Client/Module/Modules/TextHotkey/TextHotkey.cpp
+++ b/src/Client/Module/Modules/TextHotkey/TextHotkey.cpp
@@ -1,4 +1,5 @@
 #include "TextHotkey.hpp"
+#include "Events/EventManager.hpp"
 
 void TextHotkey::onEnable() {
 	Listen(this, KeyEvent, &TextHotkey::onKey)


### PR DESCRIPTION
Someone deleted the include for event manager.
This would've created massive issues later on, surprised the complier hasn't yelled at y'all.