### PR TITLE
Fix legacy builds not being triggered on Actions

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -6,7 +6,7 @@ on:
       - 'beta-*'
       - 'release-*'
   pull_request:
-    branches: [ "main", "scripting-v2" ]
+    branches: [ "main", "legacy" ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
I'm pretty sure this is the only issue? Everything else checks out. Making a commit with the prefix "release" on the legacy branch should build fine now.