### PR TITLE
Hungerbar patch

### DIFF
--- a/src/Client/Module/Modules/BetterHungerBar/BetterHungerBar.hpp
+++ b/src/Client/Module/Modules/BetterHungerBar/BetterHungerBar.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../Module.hpp"
+#include "../MovableHotbar/MovableHotbar.hpp"
 #include "Events/Game/TickEvent.hpp"
 #include "Events/Render/SetupAndRenderEvent.hpp"
 #include "Utils/Render/PositionUtils.hpp"
@@ -62,11 +63,11 @@ public:
     
     double getPredictedSaturation();
 
-	// "U" stands for the location: textures/ui/hunger_... 
-	ResourceLocation getOutlineU(ResourceLocation& originalOutlineTexture);
+    // "U" stands for the location: textures/ui/hunger_... 
+    ResourceLocation getOutlineU(ResourceLocation& originalOutlineTexture);
 
-	// "G" stands for the location: textures/gui/icons
-	ResourceLocation getOutlineG(ResourceLocation& originalOutlineTexture);
+    // "G" stands for the location: textures/gui/icons
+    ResourceLocation getOutlineG(ResourceLocation& originalOutlineTexture);
 
 };
 
@@ -75,11 +76,11 @@ public:
 class OutlineImage {
 public:
 
-	std::vector<Vec4<int>> PixelData = std::vector<Vec4<int>>(256, Vec4<int>(0, 0, 0, 0));
-	int Size = 9;
-	OutlineImage(std::string Path);
-	OutlineImage() {};
-	const unsigned char* getImageData();
-	void SaveImage(std::string name);
+    std::vector<Vec4<int>> PixelData = std::vector<Vec4<int>>(256, Vec4<int>(0, 0, 0, 0));
+    int Size = 9;
+    OutlineImage(std::string Path);
+    OutlineImage() {};
+    const unsigned char* getImageData();
+    void SaveImage(std::string name);
 
 };

--- a/src/Client/Module/Modules/BetterHungerBar/OutlineHelper.cpp
+++ b/src/Client/Module/Modules/BetterHungerBar/OutlineHelper.cpp
@@ -15,10 +15,10 @@ ResourceLocation BetterHungerBar::getOutlineU(ResourceLocation& originalOutlineT
 {
     auto currentTime = std::chrono::steady_clock::now();
     
-    // Check if we need to reprocess (every 6s)
+    // Check if we need to reprocess (every 10s)
     if (cacheInitialized) {
         auto timeSinceLastProcess = std::chrono::duration_cast<std::chrono::seconds>(currentTime - lastProcessTime);
-        if (timeSinceLastProcess.count() < 6) {
+        if (timeSinceLastProcess.count() < 10) {
             return cachedOutline;
         }
     }

--- a/src/Utils/Memory/Game/Sig/SigInit.cpp
+++ b/src/Utils/Memory/Game/Sig/SigInit.cpp
@@ -94,6 +94,7 @@ void SigInit::init2170() {
     ADD_SIG("GeneralSettingsScreenController::GeneralSettingsScreenController", "48 89 5C 24 18 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 20 FB FF FF 48 81 EC E0 05 00 00 48 8B 05 ?? ?? ?? ?? 48 33 C4 48 89 85 D0 04 00 00 45");
     ADD_SIG("Actor::baseTick", "48 8D ? ? ? ? ? 48 89 ? BA ? ? ? ? 44 8D ? ? 44 8D ? ? 66 C7 44 24 20 ? ? E8 ? ? ? ? 48 8B");
     ADD_SIG("CameraAssignAngle", "76 0E F3 0F 5C C7");
+    ADD_SIG("ResourceLocation::getFullPath", "48 89 5C 24 ? 48 89 74 24 ? 57 48 81 EC ? ? ? ? 48 8B 05 ? ? ? ? 48 33 C4 48 89 84 24 ? ? ? ? 48 8B FA 48 8B F1 48 89 54 24 ? 33 DB");
 }
 
 void SigInit::init2160() {


### PR DESCRIPTION
- The module should now work in `gamemode default`
- `Partially fixes overlapping` when using texture packs (implemented kind of quirky since it relies on the user instead of auto detecting the location of the icons in texture packs)

if somebody knows a way to auto detect the locations lemme know!