### PR TITLE
Add TNT Timer Module

### DIFF
--- a/src/Client/Module/Manager.cpp
+++ b/src/Client/Module/Manager.cpp
@@ -131,6 +131,7 @@
 #include "Modules/SensMultiplier/SensMultiplier.hpp"
 #include "Modules/Stopwatch/Stopwatch.hpp"
 #include "Modules/InventoryLock/InventoryLock.hpp"
+#include "Modules/TNTTimer/TNTTimer.hpp"
 
 #ifdef COMPILE_DOOM
 	#include "Modules/Doom/Doom.hpp"
@@ -314,6 +315,8 @@ void ModuleManager::initialize() {
 	addModule<DepthOfField>();
 
 	addModule<InventoryLock>();
+
+	addModule<TNTTimer>();
 
 #ifdef COMPILE_DOOM
 	addModule<DoomModule>();

--- a/src/Client/Module/Modules/TNTTimer/TNTTimer.cpp
+++ b/src/Client/Module/Modules/TNTTimer/TNTTimer.cpp
@@ -15,7 +15,7 @@ void TNTTimer::onDisable() {
 void TNTTimer::defaultConfig() {
 	Module::defaultConfig("core");
 
-	setDef("format", std::string("Timer: {}"));
+	setDef("format", std::string("Timer: {value}"));
 	setDef("decimalPlaces", 2);
 
 	setDef("highThreshold", 2.5f);
@@ -32,13 +32,17 @@ void TNTTimer::settingsRender(float settingsOffset) {
 	initSettingsPage();
 
 	addHeader("Timer Format");
-	addTextBox("Format", "Use {} as placeholder for seconds.", 0, "format");
+	addTextBox("Format", "Use {value} as placeholder for seconds.", 0, "format");
 	addSliderInt("Decimal Places", "0 to 3 digits.", "decimalPlaces", 3, 0);
 	extraPadding();
 
-	addHeader("Color by Time");
-	addSlider("High Threshold (s)", ">= this seconds uses High color.", "highThreshold", 10.0f, 0.0f);
-	addSlider("Mid Threshold (s)", ">= this and < High uses Mid color.", "midThreshold", 10.0f, 0.0f);
+	addHeader("Nametag");
+	addToggle("Use Color Codes", "Apply §-color to nametag.", "useColorInNametag");
+
+	bool c = getOps<bool>("useColorInNametag");
+
+	addConditionalSlider(c, "High Threshold (s)", ">= this seconds uses High color.", "highThreshold", 10.0f, 0.0f);
+	addConditionalSlider(c, "Mid Threshold (s)", ">= this and < High uses Mid color.", "midThreshold", 10.0f, 0.0f);
 
 	std::vector<std::string> colorOptions{
 		"White",
@@ -67,13 +71,11 @@ void TNTTimer::settingsRender(float settingsOffset) {
 		"Dark Purple",
 		"Amethyst"
 	};
-	addDropdown("High Color", "", colorOptions, "highColorName", true);
-	addDropdown("Mid Color", "", colorOptions, "midColorName", true);
-	addDropdown("Low Color", "", colorOptions, "lowColorName", true);
+	addConditionalDropdown(c, "High Color", "", colorOptions, "highColorName", true);
+	addConditionalDropdown(c, "Mid Color", "", colorOptions, "midColorName", true);
+	addConditionalDropdown(c, "Low Color", "", colorOptions, "lowColorName", true);
 	extraPadding();
 
-	addHeader("Nametag");
-	addToggle("Use Color Codes", "Apply §-color to nametag.", "useColorInNametag");
 
 	FlarialGUI::UnsetScrollView();
 	resetPadding();
@@ -90,7 +92,6 @@ void TNTTimer::onTickEvent(TickEvent& event) {
 	const float midTh = getOps<float>("midThreshold");
 	const int   decimals = std::clamp(getOps<int>("decimalPlaces"), 0, 3);
 	const bool  useColor = getOps<bool>("useColorInNametag");
-	const std::string& fmt = getOps<std::string>("format");
 
 	const std::string& highName = getOps<std::string>("highColorName");
 	const std::string& midName = getOps<std::string>("midColorName");
@@ -101,22 +102,28 @@ void TNTTimer::onTickEvent(TickEvent& event) {
 		auto exp = ent->getSynchedActorDataComponent();
 		if (!exp) continue;
 
-		auto data = exp->mData.mItemsArray[(unsigned char)ActorDataIDs::FuseTime];
+		auto data = exp->mData.mItemsArray[static_cast<unsigned char>(ActorDataIDs::FuseTime)];
 		if (!data) continue;
 
 		auto value = reinterpret_cast<DataItem2<int>*>(data)->mValue;
-		const float seconds = (value + 1) / 20.f;
+		const float seconds = static_cast<float>(value + 1) / 20.f;
 
 		std::ostringstream oss;
 		oss.setf(std::ios::fixed);
 		oss << std::setprecision(decimals) << seconds;
 
-		std::string label = fmt;
-		if (auto pos = label.find("{}"); pos != std::string::npos) {
-			label.replace(pos, 2, oss.str());
+		std::string label = getOps<std::string>("format");
+
+		std::string uppercaseSentence;
+		std::string search = "{VALUE}";
+
+		for (char c: label) {
+			uppercaseSentence += (char) std::toupper(c);
 		}
-		else {
-			label += " " + oss.str();
+
+		size_t pos = uppercaseSentence.find(search);
+		if (pos != std::string::npos) {
+			label.replace(pos, search.length(), oss.str());
 		}
 
 		const std::string& chosenName = (seconds >= highTh) ? highName : (seconds >= midTh) ? midName : lowName;

--- a/src/Client/Module/Modules/TNTTimer/TNTTimer.cpp
+++ b/src/Client/Module/Modules/TNTTimer/TNTTimer.cpp
@@ -1,0 +1,137 @@
+#include "TNTTimer.hpp"
+
+#include "../Nick/NickModule.hpp"
+
+void TNTTimer::onEnable() {
+	Listen(this, TickEvent, &TNTTimer::onTickEvent)
+	Module::onEnable();
+}
+
+void TNTTimer::onDisable() {
+	Deafen(this, TickEvent, &TNTTimer::onTickEvent)
+	Module::onDisable();
+}
+
+void TNTTimer::defaultConfig() {
+	Module::defaultConfig("core");
+
+	setDef("format", std::string("Timer: {}"));
+	setDef("decimalPlaces", 2);
+
+	setDef("highThreshold", 2.5f);
+	setDef("midThreshold", 1.0f);
+
+	setDef("useColorInNametag", true);
+
+	setDef("highColorName", std::string("Green"));
+	setDef("midColorName", std::string("Gold"));
+	setDef("lowColorName", std::string("Red"));
+}
+
+void TNTTimer::settingsRender(float settingsOffset) {
+	initSettingsPage();
+
+	addHeader("Timer Format");
+	addTextBox("Format", "Use {} as placeholder for seconds.", 0, "format");
+	addSliderInt("Decimal Places", "0 to 3 digits.", "decimalPlaces", 3, 0);
+	extraPadding();
+
+	addHeader("Color by Time");
+	addSlider("High Threshold (s)", ">= this seconds uses High color.", "highThreshold", 10.0f, 0.0f);
+	addSlider("Mid Threshold (s)", ">= this and < High uses Mid color.", "midThreshold", 10.0f, 0.0f);
+
+	std::vector<std::string> colorOptions{
+		"White",
+		"Black",
+		"Netherite",
+		"Gray",
+		"Iron",
+		"Quartz",
+		"Dark Gray",
+		"Red",
+		"Dark Red",
+		"Copper",
+		"Redstone",
+		"Gold",
+		"Material Gold",
+		"Green",
+		"Dark Green",
+		"Emerald",
+		"Diamond",
+		"Aqua",
+		"Dark Aqua",
+		"Blue",
+		"Dark Blue",
+		"Lapis",
+		"Light Purple",
+		"Dark Purple",
+		"Amethyst"
+	};
+	addDropdown("High Color", "", colorOptions, "highColorName", true);
+	addDropdown("Mid Color", "", colorOptions, "midColorName", true);
+	addDropdown("Low Color", "", colorOptions, "lowColorName", true);
+	extraPadding();
+
+	addHeader("Nametag");
+	addToggle("Use Color Codes", "Apply §-color to nametag.", "useColorInNametag");
+
+	FlarialGUI::UnsetScrollView();
+	resetPadding();
+}
+
+// TODO: There might be a cleaner way to handle this by processing only explosive entities.
+void TNTTimer::onTickEvent(TickEvent& event) {
+	if (!this->isEnabled()) return;
+	if (!SDK::clientInstance) return;
+	auto player = SDK::clientInstance->getLocalPlayer();
+	if (!player) return;
+
+	const float highTh = getOps<float>("highThreshold");
+	const float midTh = getOps<float>("midThreshold");
+	const int   decimals = std::clamp(getOps<int>("decimalPlaces"), 0, 3);
+	const bool  useColor = getOps<bool>("useColorInNametag");
+	const std::string& fmt = getOps<std::string>("format");
+
+	const std::string& highName = getOps<std::string>("highColorName");
+	const std::string& midName = getOps<std::string>("midColorName");
+	const std::string& lowName = getOps<std::string>("lowColorName");
+
+	for (const auto& ent : player->getLevel()->getRuntimeActorList()) {
+		if (!ent) continue;
+		auto exp = ent->getSynchedActorDataComponent();
+		if (!exp) continue;
+
+		auto data = exp->mData.mItemsArray[(unsigned char)ActorDataIDs::FuseTime];
+		if (!data) continue;
+
+		auto value = reinterpret_cast<DataItem2<int>*>(data)->mValue;
+		const float seconds = (value + 1) / 20.f;
+
+		std::ostringstream oss;
+		oss.setf(std::ios::fixed);
+		oss << std::setprecision(decimals) << seconds;
+
+		std::string label = fmt;
+		if (auto pos = label.find("{}"); pos != std::string::npos) {
+			label.replace(pos, 2, oss.str());
+		}
+		else {
+			label += " " + oss.str();
+		}
+
+		const std::string& chosenName = (seconds >= highTh) ? highName : (seconds >= midTh) ? midName : lowName;
+
+		// NOTE: This will overwrite existing nametags on explosives.
+		// Since most explosives disappear after detonation, this behavior should be safe.
+		if (useColor) {
+			auto it = NickModule::textColors.find(chosenName);
+			const std::string& prefix = (it != NickModule::textColors.end()) ? it->second : NickModule::textColors["White"];
+
+			std::string tagged = prefix + label + "§r";
+			ent->setNametag(&tagged);
+		}
+		else {
+			ent->setNametag(&label);
+		}
+	}
+}

--- a/src/Client/Module/Modules/TNTTimer/TNTTimer.hpp
+++ b/src/Client/Module/Modules/TNTTimer/TNTTimer.hpp
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "../Module.hpp"
+#include "Assets/Assets.hpp"
+#include "Events/Game/TickEvent.hpp"
+
+class TNTTimer : public Module {
+
+public:
+
+	TNTTimer() : Module("TNT Timer", "Shows a countdown until TNT explodes",
+		IDR_TIME_PNG, "", false, { "Blast", "Fuse", "Explosion", "Countdown" }) {
+	}
+
+	void onEnable() override;
+
+	void onDisable() override;
+
+	void defaultConfig() override;
+
+	void settingsRender(float settingsOffset) override;
+
+	void onTickEvent(TickEvent& event);
+};

--- a/src/Client/Module/Modules/TNTTimer/TNTTimer.hpp
+++ b/src/Client/Module/Modules/TNTTimer/TNTTimer.hpp
@@ -9,7 +9,7 @@ class TNTTimer : public Module {
 public:
 
 	TNTTimer() : Module("TNT Timer", "Shows a countdown until TNT explodes",
-		IDR_TIME_PNG, "", false, { "Blast", "Fuse", "Explosion", "Countdown" }) {
+		IDR_TIME_PNG, "", false, { "blast", "fuse", "explosion", "countdown" }) {
 	}
 
 	void onEnable() override;

--- a/src/SDK/Client/Actor/Actor.cpp
+++ b/src/SDK/Client/Actor/Actor.cpp
@@ -213,6 +213,18 @@ ActorRotationComponent *Actor::getActorRotationComponent() {
     return tryGet<ActorRotationComponent>(sig);
 }
 
+SynchedActorDataComponent* Actor::getSynchedActorDataComponent() {
+	static uintptr_t sig;
+
+	if (!VersionUtils::checkAboveOrEqual(21, 00)) {
+		if (sig == NULL) {
+			sig = Memory::findSig(std::string(GET_SIG("tryGetPrefix")) + " " + GET_SIG("Actor::getSynchedActorDataComponent"));
+		}
+	}
+
+	return tryGet<SynchedActorDataComponent>(sig);
+}
+
 ItemStack *Actor::getOffhandSlot() {
     if(VersionUtils::checkAboveOrEqual(20, 80)) {
         return getOffhandContainer()->getItem(1);

--- a/src/SDK/Client/Actor/Actor.hpp
+++ b/src/SDK/Client/Actor/Actor.hpp
@@ -19,6 +19,7 @@
 #include "Components/ActorDataFlagComponent.hpp"
 #include "Components/MobEffectsComponent.hpp"
 #include "Components/AttributesComponent.hpp"
+#include "Components/SynchedActorDataComponent.hpp"
 
 
 enum ActorFlags {
@@ -231,9 +232,11 @@ public:
 
     ActorRotationComponent *getActorRotationComponent();
 
+	SynchedActorDataComponent *getSynchedActorDataComponent();
+
     RuntimeIDComponent *getRuntimeIDComponent();
 
-    AttributesComponent* getAttributesComponent();
+	AttributesComponent* getAttributesComponent();
 
     bool isValidAABB();
 

--- a/src/SDK/Client/Actor/Components/SynchedActorDataComponent.hpp
+++ b/src/SDK/Client/Actor/Components/SynchedActorDataComponent.hpp
@@ -1,0 +1,188 @@
+#pragma once
+
+#include "../../../../Utils/Utils.hpp"
+#include "../EntityContext.hpp"
+#include <bitset>
+
+enum class ActorDataIDs : unsigned char {
+	Reserved0 = 0,
+	StructuralIntegrity = 1,
+	Variant = 2,
+	ColorIndex = 3,
+	Name = 4,
+	Owner = 5,
+	Target = 6,
+	AirSupply = 7,
+	EffectColor = 8,
+	Reserved009 = 9,
+	Reserved010 = 10,
+	Hurt = 11,
+	HurtDir = 12,
+	RowTimeLeft = 13,
+	RowTimeRight = 14,
+	Value = 15,
+	DisplayTileRuntimeId = 16,
+	DisplayOffset = 17,
+	CustomDisplay = 18,
+	Swell = 19,
+	OldSwell = 20,
+	SwellDir = 21,
+	ChargeAmount = 22,
+	DeprecatedCarryBlockRuntimeId = 23,
+	ClientEvent = 24,
+	UsingItem = 25,
+	PlayerFlags = 26,
+	PlayerIndex = 27,
+	BedPosition = 28,
+	XPower = 29,
+	YPower = 30,
+	ZPower = 31,
+	AuxPower = 32,
+	Fishx = 33,
+	Fishz = 34,
+	Fishangle = 35,
+	AuxValueData = 36,
+	LeashHolder = 37,
+	Reserved038 = 38,
+	HasNpc = 39,
+	NpcData = 40,
+	Actions = 41,
+	AirSupplyMax = 42,
+	MarkVariant = 43,
+	ContainerType = 44,
+	ContainerSize = 45,
+	ContainerStrengthModifier = 46,
+	BlockTarget = 47,
+	Inv = 48,
+	TargetA = 49,
+	TargetB = 50,
+	TargetC = 51,
+	AerialAttack = 52,
+	Reserved053 = 53,
+	Reserved054 = 54,
+	FuseTime = 55,
+	Reserved056 = 56,
+	SeatLockPassengerRotation = 57,
+	SeatLockPassengerRotationDegrees = 58,
+	SeatRotationOffset = 59,
+	SeatRotationOffsetDegrees = 60,
+	DataRadius = 61,
+	DataWaiting = 62,
+	DataParticle = 63,
+	PeekId = 64,
+	AttachFace = 65,
+	Attached = 66,
+	AttachPos = 67,
+	TradeTarget = 68,
+	Career = 69,
+	HasCommandBlock = 70,
+	CommandName = 71,
+	LastCommandOutput = 72,
+	TrackCommandOutput = 73,
+	Reserved074 = 74,
+	Strength = 75,
+	StrengthMax = 76,
+	DataSpellCastingColor = 77,
+	DataLifetimeTicks = 78,
+	PoseIndex = 79,
+	DataTickOffset = 80,
+	NametagAlwaysShow = 81,
+	Color2Index = 82,
+	NameAuthor = 83,
+	Score = 84,
+	BalloonAnchor = 85,
+	PuffedState = 86,
+	BubbleTime = 87,
+	Agent = 88,
+	SittingAmount = 89,
+	SittingAmountPrevious = 90,
+	EatingCounter = 91,
+	Reserved092 = 92,
+	LayingAmount = 93,
+	LayingAmountPrevious = 94,
+	DataDuration = 95,
+	DataSpawnTimeDeprecated = 96,
+	DataChangeRate = 97,
+	DataChangeOnPickup = 98,
+	DataPickupCount = 99,
+	InteractText = 100,
+	TradeTier = 101,
+	MaxTradeTier = 102,
+	TradeExperience = 103,
+	SkinId = 104,
+	SpawningFrames = 105,
+	CommandBlockTickDelay = 106,
+	CommandBlockExecuteOnFirstTick = 107,
+	AmbientSoundInterval = 108,
+	AmbientSoundIntervalRange = 109,
+	AmbientSoundEventName = 110,
+	FallDamageMultiplier = 111,
+	NameRawText = 112,
+	CanRideTarget = 113,
+	LowTierCuredTradeDiscount = 114,
+	HighTierCuredTradeDiscount = 115,
+	NearbyCuredTradeDiscount = 116,
+	NearbyCuredDiscountTimeStamp = 117,
+	Hitbox = 118,
+	IsBuoyant = 119,
+	FreezingEffectStrength = 120,
+	BuoyancyData = 121,
+	GoatHornCount = 122,
+	BaseRuntimeId = 123,
+	MovementSoundDistanceOffset = 124,
+	HeartbeatIntervalTicks = 125,
+	HeartbeatSoundEvent = 126,
+	PlayerLastDeathPos = 127,
+	PlayerLastDeathDimension = 128,
+	PlayerHasDied = 129,
+	CollisionBox = 130,
+	VisibleMobEffects = 131,
+	FilteredName = 132,
+	EnterBedPosition = 133,
+	SeatThirdPersonCameraRadius = 134,
+	SeatCameraRelaxDistanceSmoothing = 135,
+	Count = 136,
+};
+
+enum class DataItemType : unsigned char {
+	Byte = 0,
+	Short = 1,
+	Int = 2,
+	Float = 3,
+	String = 4,
+	CompoundTag = 5,
+	Pos = 6,
+	Int64 = 7,
+	Vec3 = 8,
+	Unknown = 9,
+};
+
+class DataItem {
+public:
+	void* vtable;
+
+	virtual ~DataItem() = default;
+	virtual uint16_t getId() const = 0;
+	virtual DataItemType getType() const = 0;
+	virtual bool isDataEqual(DataItem const& other) const = 0;
+	virtual DataItem* clone() const = 0;
+};
+
+template <typename T>
+class DataItem2 : public DataItem {
+public:
+	BUILD_ACCESS(this, T, mValue, ((0x0C + (alignof(T) - 1)) & ~(alignof(T) - 1)))
+};
+
+class SynchedActorData {
+public:
+	std::vector<DataItem*> mItemsArray;
+	std::bitset<136> mDirtyFlags;
+	std::bitset<136> mHasComponentData;
+};
+
+struct SynchedActorDataComponent : IEntityComponent {
+public:
+	SynchedActorData mData;
+};
+static_assert(sizeof(SynchedActorDataComponent) == 0x48);

--- a/src/Utils/Memory/Game/Sig/SigInit.cpp
+++ b/src/Utils/Memory/Game/Sig/SigInit.cpp
@@ -193,6 +193,7 @@ void SigInit::init2140() {
     ADD_SIG("Actor::getAABBShapeComponent", "C8 25 F2 C9 10 1B"); // 42 81 7C 09 08 + hash
     ADD_SIG("Actor::getStateVectorComponent", "C8 25 91 3C C9 0E");
     ADD_SIG("Actor::getActorRotationComponent", "10 BA CE 21 1E DC");
+	ADD_SIG("Actor::getSynchedActorDataComponent", "10 BA DC 1A 96 D4");
 
     ADD_SIG("Actor::getMobEffectsComponent", "48 89 5C 24 08 48 89 74 24 10 48 89 7C 24 18 4C 89 6C 24 20 55 41 56 41 57 48 8D 6C 24 B9 48 81 EC E0"); // 10 BA 2F B4 D6 F7
     DEPRECATE_SIG("Actor::getRuntimeIDComponent"); // 10 BA 14 14 A1 3C ?
@@ -512,6 +513,7 @@ void SigInit::init2030() {
     ADD_SIG("Actor::getStateVectorComponent", "DA BA 91 3C C9 0E");
     ADD_SIG("Actor::getMobEffectsComponent", "DA BA 2F B4 D6 F7");
     ADD_SIG("Actor::getActorRotationComponent", "DA BA CE 21 1E DC");
+	ADD_SIG("Actor::getSynchedActorDataComponent", "DA BA DC 1A 96 D4");
 
     ADD_SIG("ActorCollision::isOnGround", "40 53 48 83 EC ? 48 8B D9 BA E1 2D 1F 21"); // TODO: wrong
 


### PR DESCRIPTION
![Preview](https://github.com/user-attachments/assets/e13902ee-02d8-4b78-a3b0-0b5de763505a)

## Overview

Adds a new **TNT-Timer** module that shows remaining fuse time for explosives and can optionally colorize their nametags.

## Features

* Timer formatting (`format`, `{}` placeholder, `decimalPlaces`)
* Threshold-based colors (`high`, `mid`, `low`)
* Optional §-color in nametags
* Configurable via settings page

## Notes

* Overwrites explosive nametags (safe since they disappear after detonation)

## Related Issue

Closes [#46](https://github.com/flarialmc/dll/issues/46#issue-2470293972)