### PR TITLE
Block flarial use

### DIFF
--- a/src/Client/Hook/Hooks/Game/RaknetTick.cpp
+++ b/src/Client/Hook/Hooks/Game/RaknetTick.cpp
@@ -1,10 +1,85 @@
 #include "RaknetTick.hpp"
 #include "../../../../SDK/SDK.hpp"
 #include "ActorBaseTick.hpp"
+#include "../../../Client.hpp"
+#include "../../../../Utils/Logger/Logger.hpp"
+#include "../../../../Utils/Utils.hpp"
+
+#include <Windows.h>
+#include <algorithm>
+#include <cctype>
 #include <filesystem>
 #include <fstream>
+#include <string_view>
 
 std::string RaknetTickHook::towriteip = "";
+
+namespace {
+    constexpr std::string_view kBlockedHost = "jogar.redealone.com";
+    constexpr uint16_t kBlockedPort = 19132;
+
+    std::string sanitizeHost(std::string host) {
+        if (host.empty()) return host;
+
+        host = String::toLower(std::move(host));
+
+        // Trim whitespace characters that may appear unexpectedly
+        host.erase(std::remove_if(host.begin(), host.end(), [](unsigned char c) {
+            return std::isspace(c);
+        }), host.end());
+
+        return host;
+    }
+
+    bool hostMatchesBlocked(std::string host, uint16_t port) {
+        if (host.empty()) return false;
+
+        host = sanitizeHost(std::move(host));
+
+        auto colonPos = host.find(':');
+        std::string_view hostPart = colonPos == std::string::npos ? std::string_view(host)
+                                                                  : std::string_view(host).substr(0, colonPos);
+
+        if (hostPart != kBlockedHost) {
+            return false;
+        }
+
+        if (port == kBlockedPort) {
+            return true;
+        }
+
+        if (colonPos != std::string::npos) {
+            auto portPart = host.substr(colonPos + 1);
+            if (!portPart.empty()) {
+                try {
+                    if (std::stoi(portPart) == kBlockedPort) {
+                        return true;
+                    }
+                } catch (...) {
+                    // ignore invalid port representations
+                }
+            }
+        }
+
+        return false;
+    }
+
+    bool shouldBlockServer(RaknetConnector* raknet) {
+        if (raknet == nullptr) {
+            return false;
+        }
+
+        if (hostMatchesBlocked(raknet->JoinedIp, raknet->port)) {
+            return true;
+        }
+
+        if (hostMatchesBlocked(raknet->RawIp, raknet->port)) {
+            return true;
+        }
+
+        return false;
+    }
+}
 
 void RaknetTickHook::callback(RaknetConnector *raknet) {
     if (getAveragePingOriginal == nullptr) {
@@ -20,6 +95,18 @@ void RaknetTickHook::callback(RaknetConnector *raknet) {
         if (SDK::clientInstance->getLocalPlayer() != nullptr) {
 
             std::string ip = raknet->JoinedIp;
+
+            static bool blockTriggered = false;
+            if (!blockTriggered && shouldBlockServer(raknet)) {
+                blockTriggered = true;
+                Logger::warn("Protected server detected ({}:{}). Disabling Flarial.",
+                             raknet->JoinedIp, static_cast<int>(raknet->port));
+                MessageBoxA(nullptr,
+                            "Este servidor bloqueia o uso do Flarial. A client será desativada.",
+                            "Flarial Bloqueado",
+                            MB_OK | MB_ICONWARNING);
+                Client::disable = true;
+            }
 
             if (ip.empty() && SDK::clientInstance == nullptr) {
                 ip = "none";


### PR DESCRIPTION
This pull request introduces a server protection feature to the `RaknetTick.cpp` hook, preventing the client from connecting to a specific blocked server. The main changes include implementing logic to detect and block connections to the server `jogar.redealone.com` on port `19132`, and disabling the client with a warning message if such a connection is attempted.

**Server Protection Feature:**

* Added helper functions (`sanitizeHost`, `hostMatchesBlocked`, and `shouldBlockServer`) to detect if the Raknet connection is targeting the blocked server `jogar.redealone.com:19132`, including handling host/port variations and whitespace.
* In the `RaknetTickHook::callback` method, introduced logic to show a warning and disable the client if a connection to the blocked server is detected, ensuring the block is triggered only once per session.