### PR TITLE
Set proper user agent for Hive API requests

### DIFF
--- a/src/Utils/Hive.hpp
+++ b/src/Utils/Hive.hpp
@@ -185,7 +185,7 @@ namespace Hive {
     }
 
     inline httpResponse GetString(const std::string &URL) {
-        HINTERNET interwebs = InternetOpenA("Samsung Smart Fridge", INTERNET_OPEN_TYPE_DIRECT, NULL, NULL, NULL);
+        HINTERNET interwebs = InternetOpenA(fmt::format("FlarialClient/{}", COMMIT_HASH).c_str(), INTERNET_OPEN_TYPE_DIRECT, NULL, NULL, NULL);
         HINTERNET urlFile;
         std::string rtn;
         DWORD statusCode = 0;


### PR DESCRIPTION
Now that the fridge is no longer working, you should consider using a normal user agent.

Unlike generic user agents like `curl`, `FlarialClient` should be easy to identify, so it seems unlikely that it'll get blocked again. The API use should be below the current rate limit for most players anyway.